### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables AI assistants to interact with PostgreSQL databases using natural language queries. This server provides secure, read-only access to database schemas and allows for natural language to SQL translation.
 
+<a href="https://glama.ai/mcp/servers/@melihbirim/pg-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@melihbirim/pg-mcp/badge" alt="PostgreSQL Server MCP server" />
+</a>
+
 ## Features
 
 - 🔒 **Secure**: Read-only operations only (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH)


### PR DESCRIPTION
This PR adds a badge for the [PostgreSQL MCP Server](https://glama.ai/mcp/servers/@melihbirim/pg-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@melihbirim/pg-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@melihbirim/pg-mcp/badge" alt="PostgreSQL Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.